### PR TITLE
Add mypy style inline comment parsing

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -3,6 +3,11 @@
 Changelog
 ---------
 
+.. _release-0.5.1:
+
+0.5.1 - TBD
+    * Made FileParser do mypy style inline comments by default
+
 .. _release-0.5.0:
 
 0.5.0 - 29th August 2024

--- a/docs/api/notices.rst
+++ b/docs/api/notices.rst
@@ -25,9 +25,11 @@ The :protocol:`pytest_typing_runner.protocols.ProgramNotice` has on it the file
 location, the line number, an optional column number, a severity, and a message.
 
 Severities are currently modelled as a :protocol:`pytest_typing_runner.protocols.Severity`
-object with two default implementations:
+object with three default implementations:
 
 .. autoclass:: pytest_typing_runner.notices.NoteSeverity
+
+.. autoclass:: pytest_typing_runner.notices.WarningSeverity
 
 .. autoclass:: pytest_typing_runner.notices.ErrorSeverity
 

--- a/pytest_typing_runner/notices.py
+++ b/pytest_typing_runner/notices.py
@@ -32,6 +32,27 @@ class NoteSeverity:
         return self.display == other_display
 
 
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class WarningSeverity:
+    """
+    Represents a "warning" severity
+
+    Implements :protocol:`pytest_typing_runner.protocols.Severity`
+    """
+
+    display: str = dataclasses.field(init=False, default="warning")
+
+    def __lt__(self, other: protocols.Severity) -> bool:
+        return self.display < other.display
+
+    def __eq__(self, o: object) -> bool:
+        other_display = getattr(o, "display", None)
+        if not isinstance(other_display, str):
+            return False
+
+        return self.display == other_display
+
+
 @dataclasses.dataclass(frozen=True)
 class ErrorSeverity:
     """

--- a/pytest_typing_runner/parse/protocols.py
+++ b/pytest_typing_runner/parse/protocols.py
@@ -106,6 +106,12 @@ class CommentMatch(Protocol):
         """
 
     @property
+    def is_warning(self) -> bool:
+        """
+        Whether this match adds a warning
+        """
+
+    @property
     def is_whole_line(self) -> bool:
         """
         Whether this match is for the whole line

--- a/tests/test_notices.py
+++ b/tests/test_notices.py
@@ -54,6 +54,28 @@ class TestNoteSeverity:
         assert notices.NoteSeverity() != notices.ErrorSeverity("arg-type")
 
 
+class TestWarningSeverity:
+    def test_it_displays_note(self) -> None:
+        sev = notices.WarningSeverity()
+        assert sev.display == "warning"
+
+    def test_it_is_ordable(self) -> None:
+        sev_c = OtherSeverity("c")
+        sev_a = OtherSeverity("a")
+        sev_z = OtherSeverity("z")
+        sev_y = OtherSeverity("y")
+        sev_w1 = notices.WarningSeverity()
+        sev_w2 = notices.WarningSeverity()
+        original: Sequence[protocols.Severity] = [sev_c, sev_w1, sev_a, sev_z, sev_w2, sev_y]
+        assert sorted(original) == [sev_a, sev_c, sev_w1, sev_w2, sev_y, sev_z]
+
+    def test_it_can_be_compared(self) -> None:
+        assert notices.WarningSeverity() == notices.WarningSeverity()
+        assert notices.WarningSeverity() == OtherSeverity("warning")
+        assert notices.WarningSeverity() != OtherSeverity("other")
+        assert notices.WarningSeverity() != notices.ErrorSeverity("arg-type")
+
+
 class TestErrorSeverity:
     def test_it_displays_error_with_error_type(self) -> None:
         assert notices.ErrorSeverity("arg-type").display == "error[arg-type]"


### PR DESCRIPTION
This allows tests to have inline comments in the style of mypy tests https://github.com/python/mypy/blob/fe15ee69b9225f808f8ed735671b73c31ae1bed8/test-data/unit/README.md

Also I learnt that mypy has warning notices (seems there's only one place in mypy that uses it) and so I've made that possible too.